### PR TITLE
allow building binary

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,12 @@ systemctl start ssh2lxd.service
 journalctl -f -u ssh2lxd.service
 ```
 
+## Building from source
+
+```
+go build ./cmd/ssh2lxd/
+```
+
 ## Basic Connection
 
 To establish an SSH connection to a container running on LXD host, run:

--- a/cmd/ssh2lxd/main.go
+++ b/cmd/ssh2lxd/main.go
@@ -1,0 +1,6 @@
+package main
+
+import _ "ssh2lxd"
+
+func main() {}
+


### PR DESCRIPTION
Allowing building server from source using:

```go
go build ./cmd/ssh2lxd/
```

and explanation added to README.md